### PR TITLE
Bump firebase to ^7.21.0 to resolve gRPC dependency issues in circleci workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,9 @@ jobs:
           name: Deploy to firebase
           command: ../node_modules/.bin/firebase deploy --token $FIREBASE_DEPLOY_TOKEN
 workflows:
+  build-only:
+    jobs:
+      - build
   build-and-deploy:
     jobs:
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,9 +49,6 @@ jobs:
           name: Deploy to firebase
           command: ../node_modules/.bin/firebase deploy --token $FIREBASE_DEPLOY_TOKEN
 workflows:
-  build-only:
-    jobs:
-      - build
   build-and-deploy:
     jobs:
       - build

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "copy-to-clipboard": "^3.3.1",
     "dat.gui": "^0.7.7",
     "dot-prop-immutable": "^1.6.0",
-    "firebase": "^6.6.2",
+    "firebase": "^7.21.0",
     "glamor": "^2.20.40",
     "history": "^4.10.1",
     "homotopy-core": "file:homotopy-core",


### PR DESCRIPTION
This should resolve the failing builds for master, as far as I can tell.

I don't see any reason not to bump firebase to the current version, but if I'm missing something, please let me know.