### PR TITLE
Bump react-color to 2.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "pako": "^1.0.11",
     "react": "16.8.6",
     "react-block-ui": "^1.3.3",
-    "react-color": "2.19.0",
+    "react-color": "2.18.1",
     "react-dom": "16.8.6",
     "react-file-reader": "^1.1.4",
     "react-firebaseui": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "pako": "^1.0.11",
     "react": "16.8.6",
     "react-block-ui": "^1.3.3",
-    "react-color": "2.17.0",
+    "react-color": "2.19.0",
     "react-dom": "16.8.6",
     "react-file-reader": "^1.1.4",
     "react-firebaseui": "^3.1.2",


### PR DESCRIPTION
This is the fix mentioned in #120. That issue should be left open, probably, as the latter half is still being worked on in react-color.